### PR TITLE
Add CI GitHub Actions workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,52 @@
+name: Deploy website (Preview and production)
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checking out the repository
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Installing Nix
+        uses: cachix/install-nix-action@v16
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v10
+        with:
+          name: nickel
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Build WASM
+        run: |
+          (cd nickel; git fetch --unshallow) # Flakes needs non-shallow
+          nix build nickel/#buildWasm
+          ln -s result/nickel-repl nickel-repl
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: npm ci --only=production
+      - run: npm run build
+      - name: Deploy to Netlify
+        uses: nwtgck/actions-netlify@v1.2
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        with:
+          production-branch: 'master'
+          production-deploy: ${{ github.event_name == 'push' }}
+          publish-dir: 'public'
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: 'Deploy from GitHub Actions'
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          enable-commit-status: true
+          overwrites-pull-request-comment: false
+        if: github.repository == 'tweag/nickel-lang.org'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,48 @@
-name: Deploy website (Preview and production)
+name: Deploy
 on:
   push:
     branches:
       - master
   pull_request:
+  workflow_call:
+    inputs:
+      website_repository:
+        type: string
+        default: tweag/nickel-lang.org
+      website_ref:
+        type: string
+        default: master
+      nickel_repository:
+        type: string
+      nickel_ref:
+        type: string
+      production_deploy:
+        required: true
+        type: boolean
+    secrets:
+      CACHIX_AUTH_TOKEN:
+        required: false
+      NETLIFY_AUTH_TOKEN:
+        required: false
+      NETLIFY_SITE_ID:
+        required: false
 
 jobs:
-  build-and-test:
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Checking out the repository
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
-          submodules: recursive
+          submodules: true
+          repository: ${{ inputs.website_repository }}
+          ref: ${{ inputs.website_ref }}
+      - name: Checkout Nickel
+        if: ${{ inputs.nickel_repository && inputs.nickel_ref }}
+        run: |
+          cd nickel
+          git remote set-url origin https://github.com/${{ inputs.nickel_repository }}
+          git fetch origin ${{ inputs.nickel_ref }}
+          git checkout ${{ inputs.nickel_ref }}
       - name: Installing Nix
         uses: cachix/install-nix-action@v16
         with:
@@ -32,8 +62,10 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14
-      - run: npm ci --only=production
-      - run: npm run build
+      - name: Build
+        run: |
+          npm ci --only=production
+          npm run build
       - name: Deploy to Netlify
         uses: nwtgck/actions-netlify@v1.2
         env:
@@ -41,7 +73,7 @@ jobs:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         with:
           production-branch: 'master'
-          production-deploy: ${{ github.event_name == 'push' }}
+          production-deploy: ${{ inputs.production_deploy }}
           publish-dir: 'public'
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: 'Deploy from GitHub Actions'
@@ -49,4 +81,3 @@ jobs:
           enable-commit-comment: false
           enable-commit-status: true
           overwrites-pull-request-comment: false
-        if: github.repository == 'tweag/nickel-lang.org'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "nickel"]
+	path = nickel
+	url = git@github.com:tweag/nickel


### PR DESCRIPTION
This continuous integration workflow cross-compiles Nickel to WASM,
then builds the rest of the website, and deploys the whole thing to
Netlify using the Netlify CLI. Netlify automatic builds should
therefore be disabled. We use GitHub Actions for the build instead of
Netlify because that way we can use Nix.

The Nickel repo is tracked as a submodule. Changes to the Nickel repo
are *not* automatically reflected on the website. Instead, the website
tracks releases (once these exist). Deploying changes to Nickel on the
website requires updating the submodule reference by hand.