### PR TITLE
Change playground line comment char to `#`

### DIFF
--- a/src/ace-nickel-mode/ace-nickel-mode.js
+++ b/src/ace-nickel-mode/ace-nickel-mode.js
@@ -150,7 +150,7 @@ ace.define("ace/mode/nickel",["require","exports","module","ace/lib/oop","ace/mo
     oop.inherits(Mode, TextMode);
 
     (function () {
-        this.lineCommentStart = "//";
+        this.lineCommentStart = "#";
         this.$id = "ace/mode/nickel";
     }).call(Mode.prototype);
 


### PR DESCRIPTION
When typing `ctrl+/` to comment out code in the playground, it currently inserts `//` which, rather than commenting out the line, just results in syntax errors. This fixes that.