### PR TITLE
switch nix commands examples to stable branch

### DIFF
--- a/src/pages/getting-started.js
+++ b/src/pages/getting-started.js
@@ -15,9 +15,9 @@ import nickelLanguageDefinition from "../prism/nickel";
 // Escaping curly braces and other stuff in JSX is tiring, so we define all code examples here
 const codeExamples = {
     withNix: {
-        nix_run: `nix run --experimental-features "flakes nix-command" github:tweag/nickel -- repl
+        nix_run: `nix run --experimental-features "flakes nix-command" github:tweag/nickel/stable -- repl
 nickel>`,
-        install: `nix profile install github:tweag/nickel
+        install: `nix profile install github:tweag/nickel/stable
 nickel repl
 nickel>`,
     },


### PR DESCRIPTION
in order to keep the documentation in sync with stable nickel branch, it's important to use github:tweag/nickel/stable to not have the development version of nickel with which the documentation may not be in sync