### PR TITLE
Override ansi-to-react to work with react 18 and fix deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
       }
     },
     "nickel-repl": {
-      "version": "0.0.1"
+      "version": "0.3.1",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -47,5 +47,11 @@
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",
     "sass": "^1.55.0"
+  },
+  "overrides": {
+    "ansi-to-react": {
+      "react": "^18.2.0",
+      "react-dom": "^18.2.0"
+    }
   }
 }


### PR DESCRIPTION
Will open an issue to remember to remove the override once ansi-to-react has been updated upstream. See https://github.com/nteract/ansi-to-react/issues/80.