### PR TITLE
Automate CI for flake lock update workflow

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -17,3 +17,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
       - name: Update flake.lock
         uses: DeterminateSystems/update-flake-lock@v17
+        with:
+          # Providing a secret token is necessary for the PRs to run CI
+          # See https://github.com/DeterminateSystems/update-flake-lock#with-a-personal-authentication-token
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}


### PR DESCRIPTION
Add a personal access token to allow the update flake lock worflow to automatically trigger the CI, instead of having to do a manual action each time.