### PR TITLE
Mangle internal markdown links in the user manual

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /nickel-repl
 /node_modules/
 /public
+src/nickel-manual

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -44,17 +44,18 @@ module.exports = {
           resolve: `gatsby-transformer-remark`,
           options: {
               plugins: [
-                  `gatsby-remark-autolink-headers`,
-                  `gatsby-remark-prismjs`,
-                  {
-                      resolve: `gatsby-remark-classes`,
-                      options: {
-                          classMap: {
-                              link: "link-primary",
-                              table: "table table-striped markdown-table",
-                          }
-                      }
-                  }
+                `gatsby-remark-autolink-headers`,
+                `gatsby-remark-prismjs`,
+                {
+                    resolve: `gatsby-remark-classes`,
+                    options: {
+                        classMap: {
+                            link: "link-primary",
+                            table: "table table-striped markdown-table",
+                        }
+                    }
+                },
+                `gatsby-remark-mangle-links`
               ],
           },
         },

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -13,32 +13,6 @@ exports.onCreateWebpackConfig = ({ _stage, actions, _loaders }) => {
    to the introduction.
  */
 exports.createPages = async ({ actions, graphql, reporter }) => {
-    const result = await graphql(`
-        query {
-            allMarkdownRemark {
-              edges {
-                node {
-                  frontmatter {
-                    slug
-                  }
-                }
-              }
-            }
-        }`
-    );
-
-    result.data.allMarkdownRemark.edges.forEach(edge => {
-        const page = edge.node.frontmatter.slug;
-        let path = `/user-manual/${page}`;
-
-        actions.createRedirect({
-            fromPath: `${path}.md`,
-            toPath: path,
-            redirectInBrowser: true,
-            isPermanent: true
-        });
-    });
-
     let redirectToIntro = fromPath => (
         actions.createRedirect({
             fromPath,

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,8 @@
       }
     },
     "nickel-repl": {
-      "version": "0.0.1"
+      "version": "0.3.1",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.0.2",

--- a/plugins/gatsby-remark-mangle-links/index.js
+++ b/plugins/gatsby-remark-mangle-links/index.js
@@ -1,0 +1,10 @@
+const visit = require('unist-util-visit');
+
+module.exports = ({ markdownAST }) => {
+  visit(markdownAST, 'link', node => {
+    if (node.url.match(/^\.\//)) {
+      node.url = node.url.replace(/^\.\//, "/user-manual/").replace(/\.md$/, "");
+    }
+  });
+  return null;
+};

--- a/plugins/gatsby-remark-mangle-links/package.json
+++ b/plugins/gatsby-remark-mangle-links/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "gatsby-remark-mangle-links",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Link mangling plugin specific to nickel-lang.org",
+  "main": "index.js",
+  "dependencies": {
+    "unist-util-visit": "^2.0.3"
+  }
+}


### PR DESCRIPTION
Add a small and very specific plugin for `gatsby-transformer-remark` that mangles certain relative links in the user manual. This fixes spurious 404 errors which appeared before redirecting the user to the proper place.