### PR TITLE
Update docker image version in getting-started

### DIFF
--- a/src/pages/getting-started.js
+++ b/src/pages/getting-started.js
@@ -156,8 +156,8 @@ const IndexPage = () => {
                 <h2 id="build-using-docker">Get a Docker image</h2>
 
                 A last alternative is to use <a className={"link-primary"} href="https://www.docker.com/">Docker</a>: you can download the
-                <a className={"link-primary"} href={"https://github.com/tweag/nickel/releases/download/0.3.1/nickel-0.3.1-docker-image.tar.gz"}> nickel-0.3.1-docker-image.tar.gz</a>.
-                Please refer to the official Docker documentation to know how to load and run a Docker image.
+                <a className={"link-primary"} href={"https://github.com/tweag/nickel/releases/download/1.0.0/nickel-1.0.0-docker-image.tar.gz"}> nickel-1.0.0-docker-image.tar.gz</a>.
+                Please refer to the official Docker documentation to know how to load and run a Docker image. The image contains the Nickel interpreter symlinked to <code>/bin/nickel</code>.
 
                 <h2 id="write-your-first-configuration">Write your first configuration</h2>
 


### PR DESCRIPTION
The Getting Started guide was still linking to the 0.3.1 docker image.