### PR TITLE
Fix the docker command in getting-started.js

### DIFF
--- a/src/pages/getting-started.js
+++ b/src/pages/getting-started.js
@@ -32,7 +32,7 @@ nickel repl
 nickel>`,
     },
     withDocker: {
-        install: `docker run --rm -it ghcr.io/tweag/nickel:1.1.1 nickel repl
+        install: `docker run --rm -it ghcr.io/tweag/nickel:1.1.1 repl
 nickel>`,
     },
     firstConfig: `{


### PR DESCRIPTION
Using `docker run` already runs the `nickel` executable inside the Docker image.