### PR TITLE
Add support for more `nickel` code block annotations

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,3 +1,5 @@
+const nickelLanguageDefinition = require('./src/prism/nickel.js');
+
 module.exports = {
     siteMetadata: {
         title: "Nickel",
@@ -60,7 +62,23 @@ module.exports = {
           options: {
               plugins: [
                 `gatsby-remark-autolink-headers`,
-                `gatsby-remark-prismjs`,
+                {
+                    resolve: `gatsby-remark-prismjs`,
+                    options: {
+                        aliases: {
+                            'nickel-lines': 'nickel',
+                            'nickel-repl': 'nickel',
+                            'nickel-parse': 'nickel',
+                            'nickel-no-check': 'nickel',
+                        },
+                        languageExtensions: [
+                            {
+                                language: 'nickel',
+                                definition: nickelLanguageDefinition
+                            }
+                        ]
+                    }
+                },
                 {
                     resolve: `gatsby-remark-classes`,
                     options: {

--- a/src/pages/user-manual/{UserManualMarkdown.slug}.js
+++ b/src/pages/user-manual/{UserManualMarkdown.slug}.js
@@ -4,19 +4,7 @@ import { graphql } from "gatsby"
 import UserManualToc from "../../components/usermanual-toc";
 import {useEffect} from "react";
 
-import Prism from "prismjs";
-import "prismjs/components/prism-bash";
-import "prismjs/components/prism-yaml";
-import "prismjs/themes/prism-tomorrow.css";
-import "prismjs/plugins/command-line/prism-command-line";
-import "prismjs/plugins/command-line/prism-command-line.css";
-import nickelLanguageDefinition from "../../prism/nickel";
-
 const UserManual = ({data}) => {
-    useEffect(() => {
-        Prism.languages.nickel = nickelLanguageDefinition;
-        Prism.highlightAll();
-    }, []);
     const { userManualMarkdown: {parent: {html, headings, frontmatter} } } = data;
     const sidebarProps = {
         active: frontmatter.slug,

--- a/src/prism/nickel.js
+++ b/src/prism/nickel.js
@@ -22,4 +22,4 @@ const nickel = {
     type: /[A-Z][a-zA-Z0-9_-]*/,
 };
 
-export default nickel;
+module.exports = nickel;


### PR DESCRIPTION
This makes Prismjs understand the new code block annotations needed for https://github.com/tweag/nickel/pull/1611

This should be compatible with current manual as well.