### PR TITLE
Fix typo in Getting Started page

### DIFF
--- a/src/pages/getting-started.js
+++ b/src/pages/getting-started.js
@@ -249,8 +249,8 @@ const IndexPage = () => {
                         href="/user-manual/introduction">user manual</a>
                     . In particular, the <a
                         className={"link-primary"}
-                        href="/user-manual/tutorial">last section</a>
-                    is a slighty more advanced tutorial.
+                        href="/user-manual/tutorial">last section</a> is
+                    a slighty more advanced tutorial.
                     You will also find <a
                         className={"link-primary"}
                         href="https://github.com/tweag/nickel/tree/master/examples">examples in the repository</a>. For an overview of Nickel and the motivations behind it, see the <a


### PR DESCRIPTION
Added a space after the link to the advanced tutorial.

Before:
> In particular, the [last section](https://nickel-lang.org/user-manual/tutorial)is a slighty more advanced tutorial.

After:
> In particular, the [last section](https://nickel-lang.org/user-manual/tutorial) is a slighty more advanced tutorial.