### PR TITLE
Update link to IM from Matrix to Discord

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -24,7 +24,7 @@ const Footer = () => (
                 <Link className="btn btn-outline btn-floating m-1" to="https://github.com/tweag/nickel/discussions" role="button"
                 ><FontAwesomeIcon color="black" icon={faComments}/></Link>
 
-                <Link className="btn btn-outline btn-floating m-1" to="https://matrix.to/#/#nickel-lang:matrix.org" role="button"
+                <Link className="btn btn-outline btn-floating m-1" to="https://discord.gg/vYDnJYBmax" role="button"
                 ><FontAwesomeIcon color="black" icon={faMessage}/></Link>
 
                 <Link className="btn btn-outline-dark btn-floating m-1 ml-4" to="#" role="button"


### PR DESCRIPTION
Tweag decided to make all communication channels related to FOSS projects public, instead of hosting them internally on Slack, which wasn't contributor-friendly. We also settled on a common instant messaging platform, and for a number of reasons, Discord was picked.

Thus the Nickel instant messaging channel has been moved from Matrix to Discord. The Matrix channel is still there and is bridged with the Discord one, but we want to redirect new users directly to the Discord one.

This PR removes a mention to Matrix and updates it with the Discord's channel link.