### PR TITLE
Make the new modular configs manual section visible

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -27,6 +27,7 @@ module.exports = {
                 {name: "Tutorial", link: "/user-manual/tutorial"},
                 {name: "Syntax", link: "/user-manual/syntax"},
                 {name: "Merging", link: "/user-manual/merging"},
+                {name: "Modular Configurations", link: "/user-manual/modular-configurations"},
                 {name: "Correctness", link: "/user-manual/correctness"},
                 {name: "Typing", link: "/user-manual/typing"},
                 {name: "Contracts", link: "/user-manual/contracts"},


### PR DESCRIPTION
The new section of the manual is accessible with a direct URL, but isn't part of the table of content on the left when browsing the user manual.