### PR TITLE
Fix alignement class for Bootstrap 4 -> Bootstrap 5

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -27,7 +27,7 @@ const Footer = () => (
                 <Link className="btn btn-outline btn-floating m-1" to="https://discord.gg/vYDnJYBmax" role="button"
                 ><FontAwesomeIcon color="black" icon={faMessage}/></Link>
 
-                <Link className="btn btn-outline-dark btn-floating m-1 ml-4" to="#" role="button"
+                <Link className="btn btn-outline-dark btn-floating m-1 ms-4" to="#" role="button"
                 ><FontAwesomeIcon color="black" icon={faArrowUp}/></Link>
             </section>
         </div>

--- a/src/components/playground-clientside.js
+++ b/src/components/playground-clientside.js
@@ -20,7 +20,7 @@ export default function ClientSidePlayground(props) {
             {!isSSR && (
                 <React.Suspense fallback={
                     <div className={"text-center playground-loader mt-4"}>
-                        Loading playground <span className={"ml-2"}><FontAwesomeIcon icon={faSpinner} size={"lg"} spin/></span>
+                        Loading playground <span className={"ms-2"}><FontAwesomeIcon icon={faSpinner} size={"lg"} spin/></span>
                     </div>
                 }>
                 <LoadablePlayground {...props}/>

--- a/src/components/playground/playground.js
+++ b/src/components/playground/playground.js
@@ -62,7 +62,7 @@ export default class Playground extends React.Component {
                 <div className={"col-6 playground-tab d-flex align-items-center"}>
                     <div>
                         <button className={"btn btn-primary"} onClick={() => this.dispatchSendEvent()}>Run</button>
-                        <span className={'ml-4'}> or press</span> <kbd>Ctrl</kbd>+<kbd>Enter</kbd> or <kbd>Cmd <Command/>
+                        <span className={'ms-4'}> or press</span> <kbd>Ctrl</kbd>+<kbd>Enter</kbd> or <kbd>Cmd <Command/>
                     </kbd>+<kbd>Enter</kbd>
                     </div>
                 </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -83,7 +83,7 @@ const IndexPage = () => {
                 This configuration contains an error. Fix it and press <kbd>Ctrl</kbd>+<kbd>Enter</kbd> (or <kbd>Cmd <Command/>
               </kbd>+<kbd>Enter</kbd>) or click <span className={'btn btn-primary disabled'}>Run</span> to try your solution.
               </div>
-              <div className={'text-left landingpage-playground-wrapper'}>
+              <div className={'text-start landingpage-playground-wrapper'}>
                 <PlaygroundComponent value={codeExample} fit={'code'} mode={modes.JSON}/>
               </div>
             </div>
@@ -95,14 +95,14 @@ const IndexPage = () => {
             <div className="col-12 col-lg-4 mb-5 mb-lg-0 main-text text-center landingpage-column">
               <img src={mergeImage} className="abstract-illustration" alt={""}/>
                 <h3 className="mb-4 mt-4">Merge</h3>
-                <div className="text-left mt-4">
+                <div className="text-start mt-4">
                     Write simple, modular blocks. Merge them into a complex configuration.
                 </div>
             </div>
             <div className="col-12 col-lg-4 mb-5 mb-lg-0 main-text text-center landingpage-column">
               <img src={validateImage} className="abstract-illustration" alt={""}/>
                 <h3 className="mb-4 mt-4">Verify & Validate</h3>
-              <div className="text-left mt-4">
+              <div className="text-start mt-4">
                 <p>Use (opt-in) static typing to verify functions, if you need to. Let
                 type inference do the boring work.</p>
 
@@ -113,7 +113,7 @@ const IndexPage = () => {
             <div className="col-12 col-lg-4 main-text text-center landingpage-column">
               <img src={reuseImage} className="abstract-illustration" alt={""}/>
                 <h3 className="mb-4 mt-4">Reuse</h3>
-              <div className="text-left lt-4">
+              <div className="text-start lt-4">
                 Don't use hacks, don't reinvent the wheel: Nickel is a
                 programming language. Factorize. Reuse the generic parts. Import external libraries.
               </div>


### PR DESCRIPTION
Fixes #757.

Following #750, we've updated from Bootstrap 4 to Bootstrap 5. It seems that `text-left` and `text-right` have been replaced with `text-start` and `text-end`, hence the misalignment. I've also discovered some other breaking changes fixed in this PR (https://getbootstrap.com/docs/5.0/migration/).