### PR TITLE
Fill in missing website metadata for SEO

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -3,6 +3,8 @@ const nickelLanguageDefinition = require('./src/prism/nickel.js');
 module.exports = {
     siteMetadata: {
         title: "Nickel",
+        description: "Manage complex configurations. Modular, correct and boilerplate-free.",
+        keywords: "nickel, configuration, Infrastructure as Code, DevOps, automation, Terraform, cloud, AWS, Kubernetes, GCP, Nix, Azure, CI/CD",
         menuLinks: [
             {
                 name: 'Getting started',

--- a/src/components/layout-sidebar.js
+++ b/src/components/layout-sidebar.js
@@ -17,6 +17,8 @@ export default function Layout({ children, sidebar }) {
           site {
             siteMetadata {
               title
+              description
+              keywords
               menuLinks {
                 name
                 link
@@ -28,10 +30,10 @@ export default function Layout({ children, sidebar }) {
       render={(data) => (
         <React.Fragment>
           <Helmet
-            title={"Nickel"}
+            title={data.site.siteMetadata.title}
             meta={[
-              { name: "description", content: "Sample" },
-              { name: "keywords", content: "sample, something" },
+              { name: "description", content: data.site.siteMetadata.description },
+              { name: "keywords", content: data.site.siteMetadata.keywords },
             ]}
           ></Helmet>
           <Header menuLinks={data.site.siteMetadata.menuLinks} />

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -12,10 +12,12 @@ export default function Layout({children}) {
         site {
           siteMetadata {
             title
-             menuLinks {
-               name
-               link
-             }
+            description
+            keywords
+            menuLinks {
+              name
+              link
+            }
           }
         }
       }
@@ -23,18 +25,18 @@ export default function Layout({children}) {
             render={data => (
                 <React.Fragment>
                     <Helmet
-                        title={'Nickel'}
+                        title={data.site.siteMetadata.title}
                         meta={[
-                            {name: 'description', content: 'Sample'},
-                            {name: 'keywords', content: 'sample, something'},
+                            {name: "description", content: data.site.siteMetadata.description},
+                            {name: "keywords", content: data.site.siteMetadata.keywords},
                         ]}
                     >
                     </Helmet>
-                    <Header menuLinks={data.site.siteMetadata.menuLinks}/>
+                    <Header menuLinks={data.site.siteMetadata.menuLinks} />
                     <div>
                         {children}
                     </div>
-                    <Footer/>
+                    <Footer />
                 </React.Fragment>
             )}
         />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -69,7 +69,7 @@ const IndexPage = () => {
               </div>
 
               <div className="mt-4 mb-4 main-text">
-                Write complex configurations. Modular, correct and boilerplate-free.
+                Manage complex configurations. Modular, correct and boilerplate-free.
               </div>
             </div>
           </section>


### PR DESCRIPTION
This commit removes the embarrassing "Sample" fillers in the website's metadata, so that thumbnails and the like will show proper descriptions.

The word "Write" is also traded for "Manage", because "Write complex configuration" sounds like the goal is to write complex configuration, but that we could write simple ones as well. I feel like "Manage" better reflects the fact that the complexity is there, and we have to handle it one way or another. And Nickel is a good way.