### PR TITLE
chore: hard upgrade to latest versions of NPM dependencies

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -98,11 +98,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1772154497,
-        "narHash": "sha256-G+ik4tMr+WsDpiEFYv80ruBR/SpeEg9agUWqgXrq7UI=",
+        "lastModified": 1780520831,
+        "narHash": "sha256-hSJ3D6rupTIpR7nbLrlvpodgi2bOw7/lcNtU8E0zqug=",
         "owner": "tweag",
         "repo": "nickel",
-        "rev": "bd777d5d1c3496c6e632fc3023c0b6d08d0fafbd",
+        "rev": "83a3eeb63e2a1bc39719b6fa79ca5183eb2455d0",
         "type": "github"
       },
       "original": {

--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,5 +1,3 @@
 import "./src/styles/custom.scss";
-import "jquery/dist/jquery.min.js";
-import "popper.js/dist/popper.min";
-import "bootstrap/dist/js/bootstrap.min.js";
+import "bootstrap/dist/js/bootstrap.bundle.min.js";
 import "./src/styles/global.css";

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -44,7 +44,6 @@ module.exports = {
     },
     plugins: [
         'gatsby-plugin-netlify',
-        'gatsby-plugin-react-helmet',
         'gatsby-plugin-sharp',
         'gatsby-transformer-sharp',
         'gatsby-plugin-image',
@@ -62,7 +61,15 @@ module.exports = {
                 path: `${__dirname}/src/nickel-stdlib-doc`,
             },
         },
-        `gatsby-plugin-sass`,
+        {
+            resolve: `gatsby-plugin-sass`,
+            options: {
+                sassOptions: {
+                    quietDeps: true,
+                    silenceDeprecations: ["legacy-js-api", "import", "if-function", "color-functions", "global-builtin"],
+                },
+            },
+        },
         {
           resolve: `gatsby-transformer-remark`,
           options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,41 +8,36 @@
       "name": "nickel-lang.org",
       "version": "1.0.0",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^7.1.0",
-        "@fortawesome/free-brands-svg-icons": "^7.1.0",
-        "@fortawesome/free-solid-svg-icons": "^7.1.0",
-        "@fortawesome/react-fontawesome": "^3.1.1",
+        "@fortawesome/fontawesome-svg-core": "^7.3.0",
+        "@fortawesome/free-brands-svg-icons": "^7.3.0",
+        "@fortawesome/free-solid-svg-icons": "^7.3.0",
+        "@fortawesome/react-fontawesome": "^3.3.1",
         "@loadable/component": "^5.16.7",
-        "ace-builds": "^1.43.5",
+        "ace-builds": "^1.44.0",
         "ansi-to-react": "^6.2.6",
-        "bootstrap": "^5.3.3",
-        "create-react-class": "^15.7.0",
-        "gatsby": "^5.16",
-        "gatsby-plugin-image": "^3.15.0",
+        "bootstrap": "^5.3.8",
+        "gatsby": "^5.16.1",
+        "gatsby-plugin-image": "^3.16.0",
         "gatsby-plugin-json-remark": "^1.1.5",
         "gatsby-plugin-netlify": "^5.1.1",
-        "gatsby-plugin-react-helmet": "^6.15.0",
         "gatsby-plugin-sass": "^6.16.0",
-        "gatsby-plugin-sharp": "^5.15",
-        "gatsby-remark-autolink-headers": "^6.15.0",
+        "gatsby-plugin-sharp": "^5.16.0",
+        "gatsby-remark-autolink-headers": "^6.16.0",
         "gatsby-remark-classes": "^1.0.2",
         "gatsby-remark-prismjs": "^7.16.0",
-        "gatsby-source-filesystem": "^5.15.0",
-        "gatsby-transformer-json": "^5.15.0",
-        "gatsby-transformer-remark": "^6.15.0",
-        "gatsby-transformer-sharp": "^5.15.0",
-        "jquery": "^3.7.1",
+        "gatsby-source-filesystem": "^5.16.0",
+        "gatsby-transformer-json": "^5.16.0",
+        "gatsby-transformer-remark": "^6.16.0",
+        "gatsby-transformer-sharp": "^5.16.0",
         "nickel-repl": "file:nickel-repl",
-        "popper.js": "^1.16.1",
         "prismjs": "^1.30.0",
-        "react": "^18.3.1",
+        "react": "^19.2.7",
         "react-ace": "^14.0.1",
         "react-bootstrap": "^2.10.10",
         "react-bootstrap-icons": "^1.11.6",
-        "react-dom": "^18.3.1",
-        "react-helmet": "^6.1.0",
+        "react-dom": "^19.2.7",
         "react-markdown": "^10.1.0",
-        "sass": "^1.97.3"
+        "sass": "^1.101.0"
       }
     },
     "nickel-repl": {
@@ -655,6 +650,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.18.6.tgz",
       "integrity": "sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==",
       "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-numeric-separator instead.",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
@@ -806,6 +802,7 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
       "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.10.4"
       },
@@ -2031,50 +2028,55 @@
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw=="
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.1.0.tgz",
-      "integrity": "sha512-l/BQM7fYntsCI//du+6sEnHOP6a74UixFyOYUyz2DLMXKx+6DEhfR3F2NYGE45XH1JJuIamacb4IZs9S0ZOWLA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.0.tgz",
+      "integrity": "sha512-X/vND0Y1l9fVJ9O79UgtZnXSpz4aNF3bXlDxiJAEAm6kgeSftp9wjjBPgqzazJV8YlmxfRoeXNfSCJ48sf/Hhw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.1.0.tgz",
-      "integrity": "sha512-fNxRUk1KhjSbnbuBxlWSnBLKLBNun52ZBTcs22H/xEEzM6Ap81ZFTQ4bZBxVQGQgVY0xugKGoRcCbaKjLQ3XZA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.0.tgz",
+      "integrity": "sha512-MFbTNLDWkLJwbozDvHOZ7hwyDjQcBMBattlcOQ6ZmV5YD9bBrqdl1rNtmVjQ/lzqveXXX3sMz2Ew6fAgXoxmkw==",
+      "license": "MIT",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.1.0"
+        "@fortawesome/fontawesome-common-types": "7.3.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-brands-svg-icons": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.1.0.tgz",
-      "integrity": "sha512-9byUd9bgNfthsZAjBl6GxOu1VPHgBuRUP9juI7ZoM98h8xNPTCTagfwUFyYscdZq4Hr7gD1azMfM9s5tIWKZZA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.3.0.tgz",
+      "integrity": "sha512-W6C9ZbPWpwcUycq6U90lVbvWTrEnr01Td2x5jlO8fOtvww4kqDBMSmZqXQCc6FIIJD4kTH6G1MBRExAaSXz3yg==",
+      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.1.0"
+        "@fortawesome/fontawesome-common-types": "7.3.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.1.0.tgz",
-      "integrity": "sha512-Udu3K7SzAo9N013qt7qmm22/wo2hADdheXtBfxFTecp+ogsc0caQNRKEb7pkvvagUGOpG9wJC1ViH6WXs8oXIA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.0.tgz",
+      "integrity": "sha512-YxI/CuwWeI3nPIoYU//vkDS+3ige/67DPZ6XwMATpYEFESzO9L8zfJOKllGRgIlpT/uebrZCcvAzp3peD7GmTw==",
+      "license": "(CC-BY-4.0 AND MIT)",
       "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.1.0"
+        "@fortawesome/fontawesome-common-types": "7.3.0"
       },
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@fortawesome/react-fontawesome": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.1.1.tgz",
-      "integrity": "sha512-EDllr9hpodc21odmUywHS1alXNiCd4E8sp5GJ5s7wYINz8vSmMiNWpALTiuYODb865YyQ/NlyiN4mbXp7HCNqg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
+      "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
+      "license": "MIT",
       "engines": {
         "node": ">=20"
       },
@@ -2096,19 +2098,6 @@
       "engines": {
         "node": ">=18.0.0 <26",
         "parcel": "2.x"
-      }
-    },
-    "node_modules/@gatsbyjs/reach-router": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-2.0.1.tgz",
-      "integrity": "sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==",
-      "dependencies": {
-        "invariant": "^2.2.4",
-        "prop-types": "^15.8.1"
-      },
-      "peerDependencies": {
-        "react": "18.x",
-        "react-dom": "18.x"
       }
     },
     "node_modules/@gatsbyjs/webpack-hot-middleware": {
@@ -2655,6 +2644,78 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+    },
+    "node_modules/@internationalized/date": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/date/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@internationalized/date/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/number/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@internationalized/number/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@internationalized/string": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.9.tgz",
+      "integrity": "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.0"
+      }
+    },
+    "node_modules/@internationalized/string/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@internationalized/string/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -4313,23 +4374,27 @@
       }
     },
     "node_modules/@react-aria/ssr": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.7.tgz",
-      "integrity": "sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.10.1.tgz",
+      "integrity": "sha512-jn038/ZYmu6DpfXJ6r2U9zFFppjbc9wnApPJSCxao2RZVEqep4YyoniHSy8qv6V21/xyS4IV7W9a+X2jOjSuag==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@swc/helpers": "^0.5.0"
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
       },
       "engines": {
         "node": ">= 12"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
       }
     },
     "node_modules/@react-aria/ssr/node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -4337,7 +4402,17 @@
     "node_modules/@react-aria/ssr/node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/@react-types/shared": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.0.tgz",
+      "integrity": "sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
     },
     "node_modules/@restart/hooks": {
       "version": "0.4.16",
@@ -4354,6 +4429,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/@restart/ui/-/ui-1.9.4.tgz",
       "integrity": "sha512-N4C7haUc3vn4LTwVUPlkJN8Ach/+yIMvRuTVIhjilNHqegY60SGLrzud6errOMNJwSnmYFnt1J0H/k8FE3A4KA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@popperjs/core": "^2.11.8",
@@ -4374,6 +4450,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@restart/hooks/-/hooks-0.5.1.tgz",
       "integrity": "sha512-EMoH04NHS1pbn07iLTjIjgttuqb7qu4+/EyhAx27MHpoENcB2ZdSsLTNxmKD+WEPnZigo62Qc8zjGnNxoSE/5Q==",
+      "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3"
       },
@@ -4385,6 +4462,7 @@
       "version": "8.0.4",
       "resolved": "https://registry.npmjs.org/uncontrollable/-/uncontrollable-8.0.4.tgz",
       "integrity": "sha512-ulRWYWHvscPFc0QQXvyJjY6LIXU56f0h8pQFvhxiKk5V1fcI8gp9Ht9leVAhrVjzqMw0BgjspBINx9r6oyJUvQ==",
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=16.14.0"
       }
@@ -4439,6 +4517,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/slugify/-/slugify-1.1.2.tgz",
       "integrity": "sha512-V9nR/W0Xd9TSGXpZ4iFUcFGhuOJtZX82Fzxj1YISlbSgKvIiNa7eLEZrT0vAraPOt++KHauIVNYgGRgjc13dXA==",
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/transliterate": "^0.1.1",
         "escape-string-regexp": "^4.0.0"
@@ -4454,6 +4533,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4465,6 +4545,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@sindresorhus/transliterate/-/transliterate-0.1.2.tgz",
       "integrity": "sha512-5/kmIOY9FF32nicXH+5yLNTX4NJ4atl7jRgqAJuIn/iyDFXBktOKDxCvyGE/EzmF4ngSUvjXxQUQlQiZ5lfw+w==",
+      "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0",
         "lodash.deburr": "^4.1.0"
@@ -4480,6 +4561,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4671,6 +4753,7 @@
       "version": "1.3.15",
       "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.3.15.tgz",
       "integrity": "sha512-5WEHKGglRjq/Ae3F8UQxg+GYUIhTUEiyBT9GKPoOLU/vPTn8iZrRbdzxqvarOaGludIejJykHLMdOCdhgWqaxA==",
+      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
       }
@@ -4710,9 +4793,10 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "node_modules/@types/warning": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
-      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.4.tgz",
+      "integrity": "sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg==",
+      "license": "MIT"
     },
     "node_modules/@types/yoga-layout": {
       "version": "1.9.2",
@@ -5131,9 +5215,10 @@
       }
     },
     "node_modules/ace-builds": {
-      "version": "1.43.5",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.43.5.tgz",
-      "integrity": "sha512-iH5FLBKdB7SVn9GR37UgA/tpQS8OTWIxWAuq3Ofaw+Qbc69FfPXsXd9jeW7KRG2xKpKMqBDnu0tHBrCWY5QI7A=="
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.44.0.tgz",
+      "integrity": "sha512-PFNMSYqFdEUkul2Ntud0HvA09AgY+F1ag0UYdpMH60wNI/qOA8cB8tlTgoALMEwIdUPJK2CjrIQ7OnbiSS/ugQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/acorn": {
       "version": "7.4.1",
@@ -5378,6 +5463,24 @@
       "dependencies": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aria-hidden/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/aria-query": {
       "version": "5.3.2",
@@ -5830,6 +5933,7 @@
       "version": "5.16.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-5.16.0.tgz",
       "integrity": "sha512-dYh/VoEU5pwmM0N1TbKwdBAqMqW5lYwJsttqYYVuVaZgSE/zikak4KUC3S/qCqCbh6D8/LTeM9YhZgQKU2c8tg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@babel/types": "^7.20.7",
@@ -6119,9 +6223,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "node_modules/bootstrap": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "funding": [
         {
           "type": "github",
@@ -6132,6 +6236,7 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
+      "license": "MIT",
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
@@ -6926,6 +7031,15 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -7302,15 +7416,6 @@
       },
       "bin": {
         "create-gatsby": "cli.js"
-      }
-    },
-    "node_modules/create-react-class": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
-      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
-      "dependencies": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
       }
     },
     "node_modules/cross-fetch": {
@@ -10094,10 +10199,11 @@
       }
     },
     "node_modules/gatsby": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-5.16.0.tgz",
-      "integrity": "sha512-xVzKmYvi2UFvwmHvkW0mBW6wirMtqoenTw9aLFVWDTSvyJycka70yNk4dnaaKSJ7TwpVStYZ/Z2J5Pc1ROgJqQ==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-5.16.1.tgz",
+      "integrity": "sha512-SwwQQBM2F9ze7jI2tlZzw1spppL036x8TQ9+/0MaRlGlc7qVaUYm1jUvaH4Nge0ck4tS9VFwB0MROBxlNed+WQ==",
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/core": "^7.20.12",
@@ -10186,7 +10292,7 @@
         "gatsby-legacy-polyfills": "^3.16.0",
         "gatsby-link": "^5.16.0",
         "gatsby-page-utils": "^3.16.0",
-        "gatsby-parcel-config": "^1.16.0",
+        "gatsby-parcel-config": "1.16.0",
         "gatsby-plugin-page-creator": "^5.16.0",
         "gatsby-plugin-typescript": "^5.16.0",
         "gatsby-plugin-utils": "^4.16.0",
@@ -10464,24 +10570,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/gatsby-link": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.16.0.tgz",
-      "integrity": "sha512-1drjKlnH9Si54npVsAnT46uW7fM7xT1ISgxzMZenhoSfAZYE0ZVqu9BbOJnj784YYLVo9t7YLzQrzP8VMHBFqQ==",
-      "dependencies": {
-        "@types/reach__router": "^1.3.10",
-        "gatsby-page-utils": "^3.16.0",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0 <26"
-      },
-      "peerDependencies": {
-        "@gatsbyjs/reach-router": "^2.0.0",
-        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
-      }
-    },
     "node_modules/gatsby-page-utils": {
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-3.16.0.tgz",
@@ -10526,22 +10614,23 @@
       }
     },
     "node_modules/gatsby-plugin-image": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-image/-/gatsby-plugin-image-3.15.0.tgz",
-      "integrity": "sha512-GlcBjJgRqBfTKG7iYRzqpdlar/MeKqNKRZBlvNhqu6fit68njRotCcoH+SnQizSgt+NoSYfjVY6mOjyD2LO8Dg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-image/-/gatsby-plugin-image-3.16.0.tgz",
+      "integrity": "sha512-1RCXMce7iHr7XwilgffkOPXdcdRbb6AyRCRRW4xUJLBQnwcDpthiznNh/iBy1ZAa5ssDCh6K71KTB7dkuarojw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.20.13",
         "@babel/runtime": "^7.20.13",
         "@babel/traverse": "^7.20.13",
         "babel-jsx-utils": "^1.1.0",
-        "babel-plugin-remove-graphql-queries": "^5.15.0",
+        "babel-plugin-remove-graphql-queries": "^5.16.0",
         "camelcase": "^6.3.0",
         "chokidar": "^3.6.0",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.2.0",
-        "gatsby-core-utils": "^4.15.0",
-        "gatsby-plugin-utils": "^4.15.0",
+        "gatsby-core-utils": "^4.16.0",
+        "gatsby-plugin-utils": "^4.16.0",
         "objectFitPolyfill": "^2.3.5",
         "prop-types": "^15.8.1"
       },
@@ -10550,8 +10639,8 @@
         "gatsby": "^5.0.0-next",
         "gatsby-plugin-sharp": "^5.0.0-next",
         "gatsby-source-filesystem": "^5.0.0-next",
-        "react": "^18.0.0 || ^0.0.0",
-        "react-dom": "^18.0.0 || ^0.0.0"
+        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
       },
       "peerDependenciesMeta": {
         "gatsby-plugin-sharp": {
@@ -10663,6 +10752,7 @@
       "version": "5.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-5.16.0.tgz",
       "integrity": "sha512-SkKb7X/8A+C1bhhw/tEDPSTr8AcsTc526OisIu8fHlxLKUQ2jY7ppsvY2PimwtSCdX6euNdDafWWlfpy5XSSFA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "@babel/traverse": "^7.20.13",
@@ -10683,21 +10773,6 @@
         "gatsby": "^5.0.0-next"
       }
     },
-    "node_modules/gatsby-plugin-react-helmet": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-6.15.0.tgz",
-      "integrity": "sha512-mznXJHiRJ8qQ7lROZEmNsmhRNhxMolcJmLlnSVyfqQrik+9sjRbrzdpZtDD3MJA+/UDDtEedXyXcK4F2HorWmQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "gatsby": "^5.0.0-next",
-        "react-helmet": "^5.1.3 || ^6.0.0"
-      }
-    },
     "node_modules/gatsby-plugin-sass": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sass/-/gatsby-plugin-sass-6.16.0.tgz",
@@ -10716,9 +10791,10 @@
       }
     },
     "node_modules/gatsby-plugin-sharp": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-5.15.0.tgz",
-      "integrity": "sha512-FxwNZzug1lRimcubCKfqVc86BOwXPtYVA+Qp3XRoxPb38TJBIG+cFDMNhtJfzjUWyaDNb/hIyXf03bQsifhRDw==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-5.16.0.tgz",
+      "integrity": "sha512-MYcvpSKM39iVvagjqxCQCYEbhwv4Ql6REp93qFRxARCaDJ50tRSLvAz/i9iI4oZs0He+3AANYN2SK/GxqwV4eQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "async": "^3.2.5",
@@ -10726,15 +10802,15 @@
         "debug": "^4.3.4",
         "filenamify": "^4.3.0",
         "fs-extra": "^11.2.0",
-        "gatsby-core-utils": "^4.15.0",
-        "gatsby-plugin-utils": "^4.15.0",
+        "gatsby-core-utils": "^4.16.0",
+        "gatsby-plugin-utils": "^4.16.0",
         "lodash": "^4.17.21",
         "probe-image-size": "^7.2.3",
         "semver": "^7.5.3",
         "sharp": "^0.32.6"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0 <26"
       },
       "peerDependencies": {
         "gatsby": "^5.0.0-next"
@@ -10779,6 +10855,7 @@
       "version": "5.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-typescript/-/gatsby-plugin-typescript-5.16.0.tgz",
       "integrity": "sha512-+eE2mfmNU+AxnSCBIFU1oJIETMpfvAsBywFDPwtwDLlNl7GyQnvv0kz2OvR+jG8kjlUwBrR+71LJCg8Ydc5CSw==",
+      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.20.12",
         "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
@@ -10799,6 +10876,7 @@
       "version": "4.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-utils/-/gatsby-plugin-utils-4.16.0.tgz",
       "integrity": "sha512-5a2ui0XQBNP8vln/UyfaGBYrVpZ0oeK3fY6LjL2zx9H6wVcO5HLdjmU9yDUwQJygi2GtYW7VGQVKHfBGXMHI6A==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "fastq": "^1.16.0",
@@ -10818,27 +10896,11 @@
         "graphql": "^16.0.0"
       }
     },
-    "node_modules/gatsby-react-router-scroll": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-6.16.0.tgz",
-      "integrity": "sha512-VtbO98hc73gUyri1wRSQWGT/ENkrvVrlryKA3Xic2rFxcmup4gz2ZWR0zQ8EWJb3Nw/k9toGPd5FnXG3Fp7DuA==",
-      "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "prop-types": "^15.8.1"
-      },
-      "engines": {
-        "node": ">=18.0.0 <26"
-      },
-      "peerDependencies": {
-        "@gatsbyjs/reach-router": "^2.0.0",
-        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
-      }
-    },
     "node_modules/gatsby-remark-autolink-headers": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-6.15.0.tgz",
-      "integrity": "sha512-DXUcMqbWZIKMwIk5+EhSwfnaQMOKAs8+InVVpCLdV1Dl/Jgt+QpwLOEuaao9wDPTXQY67PGglnc6MNjoF6XM+A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-6.16.0.tgz",
+      "integrity": "sha512-o/JUg4a6YF+e4BcA7L0YD/h8uc7EMFXdGBI7yGfVP6Sy5eG11+Bl23iMtlg0tSfNskbKL0Xa02kpwytzhCxr/g==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "github-slugger": "^1.5.0",
@@ -10847,12 +10909,12 @@
         "unist-util-visit": "^2.0.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0 <26"
       },
       "peerDependencies": {
         "gatsby": "^5.0.0-next",
-        "react": "^18.0.0 || ^0.0.0",
-        "react-dom": "^18.0.0 || ^0.0.0"
+        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
       }
     },
     "node_modules/gatsby-remark-classes": {
@@ -10905,19 +10967,6 @@
         "prismjs": "^1.15.0"
       }
     },
-    "node_modules/gatsby-script": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-script/-/gatsby-script-2.16.0.tgz",
-      "integrity": "sha512-NvHn87O+/pFszK75FSR5Na00V36+ZrZH4CTaWa8iosqH/oIyH5RXrpEajGkz4tg5SG/oH/KFNcsCFWOSo8rGlg==",
-      "engines": {
-        "node": ">=18.0.0 <26"
-      },
-      "peerDependencies": {
-        "@gatsbyjs/reach-router": "^2.0.0",
-        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
-      }
-    },
     "node_modules/gatsby-sharp": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-1.16.0.tgz",
@@ -10930,49 +10979,52 @@
       }
     },
     "node_modules/gatsby-source-filesystem": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-5.15.0.tgz",
-      "integrity": "sha512-i8pJdgGEVo+M9F1BCChKg3kzxpMTsK/wddtNvUPZj47yJGNJlW3Cax6Qr8mTu8/Rm5kno4+uM8eLKjwdB0ajMQ==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-5.16.0.tgz",
+      "integrity": "sha512-z64lyDaonLpD1fHV8s9MYVBz2z6Mv3jwEntwt/KA4QKPJsH/qD1eKZ0OBSilGqEadzLw7EcgTGkTXBAz1gd8fg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "chokidar": "^3.6.0",
         "file-type": "^16.5.4",
         "fs-extra": "^11.2.0",
-        "gatsby-core-utils": "^4.15.0",
+        "gatsby-core-utils": "^4.16.0",
         "mime": "^3.0.0",
         "pretty-bytes": "^5.6.0",
         "valid-url": "^1.0.9",
         "xstate": "^4.38.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0 <26"
       },
       "peerDependencies": {
         "gatsby": "^5.0.0-next"
       }
     },
     "node_modules/gatsby-transformer-json": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-json/-/gatsby-transformer-json-5.15.0.tgz",
-      "integrity": "sha512-gulLlx8nrCpVs5OKFectSi6O6Q/SrEIi/2byf93wI85g/RRB722BvZz/jCe3nd+GwKLSkoMIOifiKlExhgdukg==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-json/-/gatsby-transformer-json-5.16.0.tgz",
+      "integrity": "sha512-CccjD7w7rNtChl2WhulMKEKrMawhP+yk2M3Pl9wP5m/o9hD1uey91L1U8mzryzxyV2A+Tp2H3/AgxuXp9NE7GQ==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "bluebird": "^3.7.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0 <26"
       },
       "peerDependencies": {
         "gatsby": "^5.0.0-next"
       }
     },
     "node_modules/gatsby-transformer-remark": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-6.15.0.tgz",
-      "integrity": "sha512-7CtIXsUIGk8dIimjcXBh6XcHyLHH7W8l5VT+Rem6IQaAOS4mWUAAKz7p+uaa3RBwsNSEDFs9Nf0kNg7fL+D8XQ==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-6.16.0.tgz",
+      "integrity": "sha512-k1uq8G+EIC1nuDLMdvX/8SgcDCN572VlmvUsRu2oLdr9o3yz3Ulxz6qScejHLDT1UpBEixMtYjtiP5NHoUquCg==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
-        "gatsby-core-utils": "^4.15.0",
+        "gatsby-core-utils": "^4.16.0",
         "gray-matter": "^4.0.3",
         "hast-util-raw": "^6.1.0",
         "hast-util-to-html": "^7.1.3",
@@ -10995,28 +11047,29 @@
         "unist-util-visit": "^2.0.3"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0 <26"
       },
       "peerDependencies": {
         "gatsby": "^5.0.0-next"
       }
     },
     "node_modules/gatsby-transformer-sharp": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-5.15.0.tgz",
-      "integrity": "sha512-VXxxwcQZAfxom/h3Mz/e+oey4+hN2rNmdZxpEP0Wt6T5FETCxjlQ3CU83j0Q+lXLMwFtbup7eslSpp/x5GB5DA==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-5.16.0.tgz",
+      "integrity": "sha512-nRmA4JYfMjMP44T76HU8P56g2LnmdnN5LCLW0uJQBsbDKMCMnzxGyvNu3UPEqpQ+kfW9P6MVmDR50JAJezH9og==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.20.13",
         "bluebird": "^3.7.2",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.2.0",
-        "gatsby-plugin-utils": "^4.15.0",
+        "gatsby-plugin-utils": "^4.16.0",
         "probe-image-size": "^7.2.3",
         "semver": "^7.5.3",
         "sharp": "^0.32.6"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0 <26"
       },
       "peerDependencies": {
         "gatsby": "^5.0.0-next",
@@ -11065,6 +11118,20 @@
       },
       "engines": {
         "node": ">=18.0.0 <26"
+      }
+    },
+    "node_modules/gatsby/node_modules/@gatsbyjs/reach-router": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-2.0.1.tgz",
+      "integrity": "sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "react": "18.x",
+        "react-dom": "18.x"
       }
     },
     "node_modules/gatsby/node_modules/@typescript-eslint/eslint-plugin": {
@@ -11395,6 +11462,57 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/gatsby/node_modules/gatsby-link": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.16.0.tgz",
+      "integrity": "sha512-1drjKlnH9Si54npVsAnT46uW7fM7xT1ISgxzMZenhoSfAZYE0ZVqu9BbOJnj784YYLVo9t7YLzQrzP8VMHBFqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/reach__router": "^1.3.10",
+        "gatsby-page-utils": "^3.16.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0 <26"
+      },
+      "peerDependencies": {
+        "@gatsbyjs/reach-router": "^2.0.0",
+        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
+      }
+    },
+    "node_modules/gatsby/node_modules/gatsby-react-router-scroll": {
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-6.16.0.tgz",
+      "integrity": "sha512-VtbO98hc73gUyri1wRSQWGT/ENkrvVrlryKA3Xic2rFxcmup4gz2ZWR0zQ8EWJb3Nw/k9toGPd5FnXG3Fp7DuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=18.0.0 <26"
+      },
+      "peerDependencies": {
+        "@gatsbyjs/reach-router": "^2.0.0",
+        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
+      }
+    },
+    "node_modules/gatsby/node_modules/gatsby-script": {
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-script/-/gatsby-script-2.16.0.tgz",
+      "integrity": "sha512-NvHn87O+/pFszK75FSR5Na00V36+ZrZH4CTaWa8iosqH/oIyH5RXrpEajGkz4tg5SG/oH/KFNcsCFWOSo8rGlg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0 <26"
+      },
+      "peerDependencies": {
+        "@gatsbyjs/reach-router": "^2.0.0",
+        "react": "^18.0.0 || ^19.0.0 || ^0.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^0.0.0"
       }
     },
     "node_modules/gatsby/node_modules/has-flag": {
@@ -12597,9 +12715,10 @@
       }
     },
     "node_modules/immutable": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
-      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw=="
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -13548,11 +13667,6 @@
         "@sideway/pinpoint": "^2.0.0"
       }
     },
-    "node_modules/jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -13834,7 +13948,8 @@
     "node_modules/lodash.deburr": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
-      "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ=="
+      "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
+      "license": "MIT"
     },
     "node_modules/lodash.every": {
       "version": "4.6.0",
@@ -16904,16 +17019,6 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -17803,12 +17908,10 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -17829,6 +17932,42 @@
         "react": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/react-aria": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.50.0.tgz",
+      "integrity": "sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.48.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1",
+        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-aria/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/react-aria/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/react-bootstrap": {
       "version": "2.10.10",
@@ -18058,48 +18197,21 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
-    },
-    "node_modules/react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-    },
-    "node_modules/react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
-      "dependencies": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.3.0"
-      }
-    },
-    "node_modules/react-helmet/node_modules/react-side-effect": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
-      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
-      "peerDependencies": {
-        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
-      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -18415,10 +18527,43 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-stately": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.48.0.tgz",
+      "integrity": "sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1"
+      }
+    },
+    "node_modules/react-stately/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/react-stately/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
       "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
@@ -19423,19 +19568,20 @@
       }
     },
     "node_modules/sass": {
-      "version": "1.97.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
+      "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
+      "license": "MIT",
       "dependencies": {
-        "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "bin": {
         "sass": "sass.js"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.19.0"
       },
       "optionalDependencies": {
         "@parcel/watcher": "^2.4.1"
@@ -19506,25 +19652,27 @@
       }
     },
     "node_modules/sass/node_modules/chokidar": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.0.tgz",
-      "integrity": "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
+      "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/sass/node_modules/readdirp": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
-      "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -19540,12 +19688,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "2.7.1",
@@ -21719,6 +21865,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -23957,38 +24112,38 @@
       "integrity": "sha512-HHQigo3rQWKMDzYDLkubN5WQOYXJJE2eNqIQC2axC2iO3mHdwnIR7FgZVvHWtBwAdzBgAP0ECp8KqS8TiMKvgw=="
     },
     "@fortawesome/fontawesome-common-types": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.1.0.tgz",
-      "integrity": "sha512-l/BQM7fYntsCI//du+6sEnHOP6a74UixFyOYUyz2DLMXKx+6DEhfR3F2NYGE45XH1JJuIamacb4IZs9S0ZOWLA=="
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.0.tgz",
+      "integrity": "sha512-X/vND0Y1l9fVJ9O79UgtZnXSpz4aNF3bXlDxiJAEAm6kgeSftp9wjjBPgqzazJV8YlmxfRoeXNfSCJ48sf/Hhw=="
     },
     "@fortawesome/fontawesome-svg-core": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.1.0.tgz",
-      "integrity": "sha512-fNxRUk1KhjSbnbuBxlWSnBLKLBNun52ZBTcs22H/xEEzM6Ap81ZFTQ4bZBxVQGQgVY0xugKGoRcCbaKjLQ3XZA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.0.tgz",
+      "integrity": "sha512-MFbTNLDWkLJwbozDvHOZ7hwyDjQcBMBattlcOQ6ZmV5YD9bBrqdl1rNtmVjQ/lzqveXXX3sMz2Ew6fAgXoxmkw==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "7.1.0"
+        "@fortawesome/fontawesome-common-types": "7.3.0"
       }
     },
     "@fortawesome/free-brands-svg-icons": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.1.0.tgz",
-      "integrity": "sha512-9byUd9bgNfthsZAjBl6GxOu1VPHgBuRUP9juI7ZoM98h8xNPTCTagfwUFyYscdZq4Hr7gD1azMfM9s5tIWKZZA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-7.3.0.tgz",
+      "integrity": "sha512-W6C9ZbPWpwcUycq6U90lVbvWTrEnr01Td2x5jlO8fOtvww4kqDBMSmZqXQCc6FIIJD4kTH6G1MBRExAaSXz3yg==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "7.1.0"
+        "@fortawesome/fontawesome-common-types": "7.3.0"
       }
     },
     "@fortawesome/free-solid-svg-icons": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.1.0.tgz",
-      "integrity": "sha512-Udu3K7SzAo9N013qt7qmm22/wo2hADdheXtBfxFTecp+ogsc0caQNRKEb7pkvvagUGOpG9wJC1ViH6WXs8oXIA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.0.tgz",
+      "integrity": "sha512-YxI/CuwWeI3nPIoYU//vkDS+3ige/67DPZ6XwMATpYEFESzO9L8zfJOKllGRgIlpT/uebrZCcvAzp3peD7GmTw==",
       "requires": {
-        "@fortawesome/fontawesome-common-types": "7.1.0"
+        "@fortawesome/fontawesome-common-types": "7.3.0"
       }
     },
     "@fortawesome/react-fontawesome": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.1.1.tgz",
-      "integrity": "sha512-EDllr9hpodc21odmUywHS1alXNiCd4E8sp5GJ5s7wYINz8vSmMiNWpALTiuYODb865YyQ/NlyiN4mbXp7HCNqg==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.3.1.tgz",
+      "integrity": "sha512-wGnAPhfzivDwBWYmEG8MSrEXPruoiMMo48NnsRkj1NZkoaawgOijPNAiSHKMYEoCsqTBSgLTzL6EqTTWGaUR4w==",
       "requires": {}
     },
     "@gatsbyjs/parcel-namer-relative-to-cwd": {
@@ -24000,15 +24155,6 @@
         "@parcel/namer-default": "2.8.3",
         "@parcel/plugin": "2.8.3",
         "gatsby-core-utils": "^4.16.0"
-      }
-    },
-    "@gatsbyjs/reach-router": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-2.0.1.tgz",
-      "integrity": "sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==",
-      "requires": {
-        "invariant": "^2.2.4",
-        "prop-types": "^15.8.1"
       }
     },
     "@gatsbyjs/webpack-hot-middleware": {
@@ -24514,6 +24660,75 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
+    },
+    "@internationalized/date": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.2.tgz",
+      "integrity": "sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==",
+      "requires": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "dependencies": {
+        "@swc/helpers": {
+          "version": "0.5.23",
+          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+          "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+          "requires": {
+            "tslib": "^2.8.0"
+          }
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@internationalized/number": {
+      "version": "3.6.7",
+      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.7.tgz",
+      "integrity": "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==",
+      "requires": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "dependencies": {
+        "@swc/helpers": {
+          "version": "0.5.23",
+          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+          "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+          "requires": {
+            "tslib": "^2.8.0"
+          }
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
+    },
+    "@internationalized/string": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.9.tgz",
+      "integrity": "sha512-kzP/M/mbQxODlmOt4bIQZ2SBVUWUSqMLXooXixnX7noche8WHaQcA+nwFN1K2KCF/cp+LDUhcJsCicwkvhD1pg==",
+      "requires": {
+        "@swc/helpers": "^0.5.0"
+      },
+      "dependencies": {
+        "@swc/helpers": {
+          "version": "0.5.23",
+          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+          "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+          "requires": {
+            "tslib": "^2.8.0"
+          }
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
     },
     "@isaacs/cliui": {
       "version": "8.0.2",
@@ -25488,17 +25703,18 @@
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@react-aria/ssr": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.7.tgz",
-      "integrity": "sha512-GQygZaGlmYjmYM+tiNBA5C6acmiDWF52Nqd40bBp0Znk4M4hP+LTmI0lpI1BuKMw45T8RIhrAsICIfKwZvi2Gg==",
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.10.1.tgz",
+      "integrity": "sha512-jn038/ZYmu6DpfXJ6r2U9zFFppjbc9wnApPJSCxao2RZVEqep4YyoniHSy8qv6V21/xyS4IV7W9a+X2jOjSuag==",
       "requires": {
-        "@swc/helpers": "^0.5.0"
+        "@swc/helpers": "^0.5.0",
+        "react-aria": "^3.48.0"
       },
       "dependencies": {
         "@swc/helpers": {
-          "version": "0.5.15",
-          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-          "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+          "version": "0.5.23",
+          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+          "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
           "requires": {
             "tslib": "^2.8.0"
           }
@@ -25509,6 +25725,12 @@
           "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
         }
       }
+    },
+    "@react-types/shared": {
+      "version": "3.36.0",
+      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.36.0.tgz",
+      "integrity": "sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==",
+      "requires": {}
     },
     "@restart/hooks": {
       "version": "0.4.16",
@@ -25846,9 +26068,9 @@
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
     "@types/warning": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.3.tgz",
-      "integrity": "sha512-D1XC7WK8K+zZEveUPY+cf4+kgauk8N4eHr/XIHXGlGYkHLud6hK9lYfZk1ry1TNh798cZUCgb6MqGEG8DkJt6Q=="
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/warning/-/warning-3.0.4.tgz",
+      "integrity": "sha512-CqN8MnISMwQbLJXO3doBAV4Yw9hx9/Pyr2rZ78+NfaCnhyRA/nKrpyk6E7mKw17ZOaQdLpK9GiUjrqLzBlN3sg=="
     },
     "@types/yoga-layout": {
       "version": "1.9.2",
@@ -26159,9 +26381,9 @@
       }
     },
     "ace-builds": {
-      "version": "1.43.5",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.43.5.tgz",
-      "integrity": "sha512-iH5FLBKdB7SVn9GR37UgA/tpQS8OTWIxWAuq3Ofaw+Qbc69FfPXsXd9jeW7KRG2xKpKMqBDnu0tHBrCWY5QI7A=="
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.44.0.tgz",
+      "integrity": "sha512-PFNMSYqFdEUkul2Ntud0HvA09AgY+F1ag0UYdpMH60wNI/qOA8cB8tlTgoALMEwIdUPJK2CjrIQ7OnbiSS/ugQ=="
     },
     "acorn": {
       "version": "7.4.1",
@@ -26332,6 +26554,21 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
       }
     },
     "aria-query": {
@@ -26862,9 +27099,9 @@
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24="
     },
     "bootstrap": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
-      "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.8.tgz",
+      "integrity": "sha512-HP1SZDqaLDPwsNiqRqi5NcP0SSXciX2s9E+RyqJIIqGo+vJeN5AJVM98CXmW/Wux0nQ5L7jeWUdplCEf0Ee+tg==",
       "requires": {}
     },
     "boxen": {
@@ -27417,6 +27654,11 @@
         "mimic-response": "^1.0.0"
       }
     },
+    "clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
+    },
     "color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -27706,15 +27948,6 @@
       "integrity": "sha512-F2gzKq1Pl3wFzHOIZdA2XEiynt0sPxnq0ccwzbz4YFZxGf5vLG16ijTvnmZjJzm/LSSP+szedX5cA0c6a+mnjg==",
       "requires": {
         "@babel/runtime": "^7.20.13"
-      }
-    },
-    "create-react-class": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/create-react-class/-/create-react-class-15.7.0.tgz",
-      "integrity": "sha512-QZv4sFWG9S5RUvkTYWbflxeZX+JG7Cz0Tn33rQBJ+WFQTqTfUTjMjiv9tnfXazjsO5r0KhPs+AqCjyrQX6h2ng==",
-      "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
       }
     },
     "cross-fetch": {
@@ -29734,9 +29967,9 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
     },
     "gatsby": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-5.16.0.tgz",
-      "integrity": "sha512-xVzKmYvi2UFvwmHvkW0mBW6wirMtqoenTw9aLFVWDTSvyJycka70yNk4dnaaKSJ7TwpVStYZ/Z2J5Pc1ROgJqQ==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-5.16.1.tgz",
+      "integrity": "sha512-SwwQQBM2F9ze7jI2tlZzw1spppL036x8TQ9+/0MaRlGlc7qVaUYm1jUvaH4Nge0ck4tS9VFwB0MROBxlNed+WQ==",
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/core": "^7.20.12",
@@ -29825,7 +30058,7 @@
         "gatsby-legacy-polyfills": "^3.16.0",
         "gatsby-link": "^5.16.0",
         "gatsby-page-utils": "^3.16.0",
-        "gatsby-parcel-config": "^1.16.0",
+        "gatsby-parcel-config": "1.16.0",
         "gatsby-plugin-page-creator": "^5.16.0",
         "gatsby-plugin-typescript": "^5.16.0",
         "gatsby-plugin-utils": "^4.16.0",
@@ -29907,6 +30140,15 @@
         "yaml-loader": "^0.8.0"
       },
       "dependencies": {
+        "@gatsbyjs/reach-router": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/@gatsbyjs/reach-router/-/reach-router-2.0.1.tgz",
+          "integrity": "sha512-gmSZniS9/phwgEgpFARMpNg21PkYDZEpfgEzvkgpE/iku4uvXqCrxr86fXbTpI9mkrhKS1SCTYmLGe60VdHcdQ==",
+          "requires": {
+            "invariant": "^2.2.4",
+            "prop-types": "^15.8.1"
+          }
+        },
         "@typescript-eslint/eslint-plugin": {
           "version": "5.62.0",
           "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.62.0.tgz",
@@ -30092,6 +30334,31 @@
           "version": "3.4.3",
           "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
           "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="
+        },
+        "gatsby-link": {
+          "version": "5.16.0",
+          "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.16.0.tgz",
+          "integrity": "sha512-1drjKlnH9Si54npVsAnT46uW7fM7xT1ISgxzMZenhoSfAZYE0ZVqu9BbOJnj784YYLVo9t7YLzQrzP8VMHBFqQ==",
+          "requires": {
+            "@types/reach__router": "^1.3.10",
+            "gatsby-page-utils": "^3.16.0",
+            "prop-types": "^15.8.1"
+          }
+        },
+        "gatsby-react-router-scroll": {
+          "version": "6.16.0",
+          "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-6.16.0.tgz",
+          "integrity": "sha512-VtbO98hc73gUyri1wRSQWGT/ENkrvVrlryKA3Xic2rFxcmup4gz2ZWR0zQ8EWJb3Nw/k9toGPd5FnXG3Fp7DuA==",
+          "requires": {
+            "@babel/runtime": "^7.20.13",
+            "prop-types": "^15.8.1"
+          }
+        },
+        "gatsby-script": {
+          "version": "2.16.0",
+          "resolved": "https://registry.npmjs.org/gatsby-script/-/gatsby-script-2.16.0.tgz",
+          "integrity": "sha512-NvHn87O+/pFszK75FSR5Na00V36+ZrZH4CTaWa8iosqH/oIyH5RXrpEajGkz4tg5SG/oH/KFNcsCFWOSo8rGlg==",
+          "requires": {}
         },
         "has-flag": {
           "version": "4.0.0",
@@ -30433,16 +30700,6 @@
         }
       }
     },
-    "gatsby-link": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-5.16.0.tgz",
-      "integrity": "sha512-1drjKlnH9Si54npVsAnT46uW7fM7xT1ISgxzMZenhoSfAZYE0ZVqu9BbOJnj784YYLVo9t7YLzQrzP8VMHBFqQ==",
-      "requires": {
-        "@types/reach__router": "^1.3.10",
-        "gatsby-page-utils": "^3.16.0",
-        "prop-types": "^15.8.1"
-      }
-    },
     "gatsby-page-utils": {
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-3.16.0.tgz",
@@ -30478,22 +30735,22 @@
       }
     },
     "gatsby-plugin-image": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-image/-/gatsby-plugin-image-3.15.0.tgz",
-      "integrity": "sha512-GlcBjJgRqBfTKG7iYRzqpdlar/MeKqNKRZBlvNhqu6fit68njRotCcoH+SnQizSgt+NoSYfjVY6mOjyD2LO8Dg==",
+      "version": "3.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-image/-/gatsby-plugin-image-3.16.0.tgz",
+      "integrity": "sha512-1RCXMce7iHr7XwilgffkOPXdcdRbb6AyRCRRW4xUJLBQnwcDpthiznNh/iBy1ZAa5ssDCh6K71KTB7dkuarojw==",
       "requires": {
         "@babel/code-frame": "^7.18.6",
         "@babel/parser": "^7.20.13",
         "@babel/runtime": "^7.20.13",
         "@babel/traverse": "^7.20.13",
         "babel-jsx-utils": "^1.1.0",
-        "babel-plugin-remove-graphql-queries": "^5.15.0",
+        "babel-plugin-remove-graphql-queries": "^5.16.0",
         "camelcase": "^6.3.0",
         "chokidar": "^3.6.0",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.2.0",
-        "gatsby-core-utils": "^4.15.0",
-        "gatsby-plugin-utils": "^4.15.0",
+        "gatsby-core-utils": "^4.16.0",
+        "gatsby-plugin-utils": "^4.16.0",
         "objectFitPolyfill": "^2.3.5",
         "prop-types": "^15.8.1"
       }
@@ -30588,14 +30845,6 @@
         "lodash": "^4.17.21"
       }
     },
-    "gatsby-plugin-react-helmet": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-6.15.0.tgz",
-      "integrity": "sha512-mznXJHiRJ8qQ7lROZEmNsmhRNhxMolcJmLlnSVyfqQrik+9sjRbrzdpZtDD3MJA+/UDDtEedXyXcK4F2HorWmQ==",
-      "requires": {
-        "@babel/runtime": "^7.20.13"
-      }
-    },
     "gatsby-plugin-sass": {
       "version": "6.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sass/-/gatsby-plugin-sass-6.16.0.tgz",
@@ -30607,9 +30856,9 @@
       }
     },
     "gatsby-plugin-sharp": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-5.15.0.tgz",
-      "integrity": "sha512-FxwNZzug1lRimcubCKfqVc86BOwXPtYVA+Qp3XRoxPb38TJBIG+cFDMNhtJfzjUWyaDNb/hIyXf03bQsifhRDw==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-5.16.0.tgz",
+      "integrity": "sha512-MYcvpSKM39iVvagjqxCQCYEbhwv4Ql6REp93qFRxARCaDJ50tRSLvAz/i9iI4oZs0He+3AANYN2SK/GxqwV4eQ==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "async": "^3.2.5",
@@ -30617,8 +30866,8 @@
         "debug": "^4.3.4",
         "filenamify": "^4.3.0",
         "fs-extra": "^11.2.0",
-        "gatsby-core-utils": "^4.15.0",
-        "gatsby-plugin-utils": "^4.15.0",
+        "gatsby-core-utils": "^4.16.0",
+        "gatsby-plugin-utils": "^4.16.0",
         "lodash": "^4.17.21",
         "probe-image-size": "^7.2.3",
         "semver": "^7.5.3",
@@ -30683,19 +30932,10 @@
         "mime": "^3.0.0"
       }
     },
-    "gatsby-react-router-scroll": {
-      "version": "6.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-6.16.0.tgz",
-      "integrity": "sha512-VtbO98hc73gUyri1wRSQWGT/ENkrvVrlryKA3Xic2rFxcmup4gz2ZWR0zQ8EWJb3Nw/k9toGPd5FnXG3Fp7DuA==",
-      "requires": {
-        "@babel/runtime": "^7.20.13",
-        "prop-types": "^15.8.1"
-      }
-    },
     "gatsby-remark-autolink-headers": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-6.15.0.tgz",
-      "integrity": "sha512-DXUcMqbWZIKMwIk5+EhSwfnaQMOKAs8+InVVpCLdV1Dl/Jgt+QpwLOEuaao9wDPTXQY67PGglnc6MNjoF6XM+A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-remark-autolink-headers/-/gatsby-remark-autolink-headers-6.16.0.tgz",
+      "integrity": "sha512-o/JUg4a6YF+e4BcA7L0YD/h8uc7EMFXdGBI7yGfVP6Sy5eG11+Bl23iMtlg0tSfNskbKL0Xa02kpwytzhCxr/g==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "github-slugger": "^1.5.0",
@@ -30749,12 +30989,6 @@
         "unist-util-visit": "^2.0.3"
       }
     },
-    "gatsby-script": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/gatsby-script/-/gatsby-script-2.16.0.tgz",
-      "integrity": "sha512-NvHn87O+/pFszK75FSR5Na00V36+ZrZH4CTaWa8iosqH/oIyH5RXrpEajGkz4tg5SG/oH/KFNcsCFWOSo8rGlg==",
-      "requires": {}
-    },
     "gatsby-sharp": {
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-1.16.0.tgz",
@@ -30764,15 +30998,15 @@
       }
     },
     "gatsby-source-filesystem": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-5.15.0.tgz",
-      "integrity": "sha512-i8pJdgGEVo+M9F1BCChKg3kzxpMTsK/wddtNvUPZj47yJGNJlW3Cax6Qr8mTu8/Rm5kno4+uM8eLKjwdB0ajMQ==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-5.16.0.tgz",
+      "integrity": "sha512-z64lyDaonLpD1fHV8s9MYVBz2z6Mv3jwEntwt/KA4QKPJsH/qD1eKZ0OBSilGqEadzLw7EcgTGkTXBAz1gd8fg==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "chokidar": "^3.6.0",
         "file-type": "^16.5.4",
         "fs-extra": "^11.2.0",
-        "gatsby-core-utils": "^4.15.0",
+        "gatsby-core-utils": "^4.16.0",
         "mime": "^3.0.0",
         "pretty-bytes": "^5.6.0",
         "valid-url": "^1.0.9",
@@ -30780,21 +31014,21 @@
       }
     },
     "gatsby-transformer-json": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-json/-/gatsby-transformer-json-5.15.0.tgz",
-      "integrity": "sha512-gulLlx8nrCpVs5OKFectSi6O6Q/SrEIi/2byf93wI85g/RRB722BvZz/jCe3nd+GwKLSkoMIOifiKlExhgdukg==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-json/-/gatsby-transformer-json-5.16.0.tgz",
+      "integrity": "sha512-CccjD7w7rNtChl2WhulMKEKrMawhP+yk2M3Pl9wP5m/o9hD1uey91L1U8mzryzxyV2A+Tp2H3/AgxuXp9NE7GQ==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "bluebird": "^3.7.2"
       }
     },
     "gatsby-transformer-remark": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-6.15.0.tgz",
-      "integrity": "sha512-7CtIXsUIGk8dIimjcXBh6XcHyLHH7W8l5VT+Rem6IQaAOS4mWUAAKz7p+uaa3RBwsNSEDFs9Nf0kNg7fL+D8XQ==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-6.16.0.tgz",
+      "integrity": "sha512-k1uq8G+EIC1nuDLMdvX/8SgcDCN572VlmvUsRu2oLdr9o3yz3Ulxz6qScejHLDT1UpBEixMtYjtiP5NHoUquCg==",
       "requires": {
         "@babel/runtime": "^7.20.13",
-        "gatsby-core-utils": "^4.15.0",
+        "gatsby-core-utils": "^4.16.0",
         "gray-matter": "^4.0.3",
         "hast-util-raw": "^6.1.0",
         "hast-util-to-html": "^7.1.3",
@@ -30818,15 +31052,15 @@
       }
     },
     "gatsby-transformer-sharp": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-5.15.0.tgz",
-      "integrity": "sha512-VXxxwcQZAfxom/h3Mz/e+oey4+hN2rNmdZxpEP0Wt6T5FETCxjlQ3CU83j0Q+lXLMwFtbup7eslSpp/x5GB5DA==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-5.16.0.tgz",
+      "integrity": "sha512-nRmA4JYfMjMP44T76HU8P56g2LnmdnN5LCLW0uJQBsbDKMCMnzxGyvNu3UPEqpQ+kfW9P6MVmDR50JAJezH9og==",
       "requires": {
         "@babel/runtime": "^7.20.13",
         "bluebird": "^3.7.2",
         "common-tags": "^1.8.2",
         "fs-extra": "^11.2.0",
-        "gatsby-plugin-utils": "^4.15.0",
+        "gatsby-plugin-utils": "^4.16.0",
         "probe-image-size": "^7.2.3",
         "semver": "^7.5.3",
         "sharp": "^0.32.6"
@@ -31509,9 +31743,9 @@
       "integrity": "sha512-ubBeqQutOSLIFCUBN03jGeOS6a3DoYlSYwYJTa+gSKEZKU5redJIqkIdZ3JVv/4RZpfcXdAWH5zCNLWPRv2WDw=="
     },
     "immutable": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.0.3.tgz",
-      "integrity": "sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw=="
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -32144,11 +32378,6 @@
         "@sideway/formula": "^3.0.1",
         "@sideway/pinpoint": "^2.0.0"
       }
-    },
-    "jquery": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
-      "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -34548,11 +34777,6 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
     "possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -35126,12 +35350,9 @@
       }
     },
     "react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="
     },
     "react-ace": {
       "version": "14.0.1",
@@ -35143,6 +35364,37 @@
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
         "prop-types": "^15.8.1"
+      }
+    },
+    "react-aria": {
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/react-aria/-/react-aria-3.50.0.tgz",
+      "integrity": "sha512-S0Os6QZk33fzUAKu1QLT9afoUaCBt1ZNdoiq0n2YMVgKIdNIQS8zxiZ8O9hYE6QyDkHKjD6q39LQZ+qaSAIgjw==",
+      "requires": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "aria-hidden": "^1.2.3",
+        "clsx": "^2.0.0",
+        "react-stately": "3.48.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "dependencies": {
+        "@swc/helpers": {
+          "version": "0.5.23",
+          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+          "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+          "requires": {
+            "tslib": "^2.8.0"
+          }
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
       }
     },
     "react-bootstrap": {
@@ -35300,42 +35552,17 @@
       }
     },
     "react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "requires": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       }
     },
     "react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
-    },
-    "react-fast-compare": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
-      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
-    },
-    "react-helmet": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
-      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
-      "requires": {
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.1.1",
-        "react-side-effect": "^2.1.0"
-      },
-      "dependencies": {
-        "react-side-effect": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
-          "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
-          "requires": {}
-        }
-      }
     },
     "react-is": {
       "version": "16.13.1",
@@ -35568,6 +35795,34 @@
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="
+    },
+    "react-stately": {
+      "version": "3.48.0",
+      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.48.0.tgz",
+      "integrity": "sha512-ImicSAG+lTotAe5izcs1fz49Zk48w7pDusqYg04WaPhCoej8BJ24soMu3iLXIrsi273s4P1gZrYGrqReMfgEEA==",
+      "requires": {
+        "@internationalized/date": "^3.12.2",
+        "@internationalized/number": "^3.6.7",
+        "@internationalized/string": "^3.2.9",
+        "@react-types/shared": "^3.36.0",
+        "@swc/helpers": "^0.5.0",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "dependencies": {
+        "@swc/helpers": {
+          "version": "0.5.23",
+          "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+          "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+          "requires": {
+            "tslib": "^2.8.0"
+          }
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
     },
     "react-transition-group": {
       "version": "4.4.5",
@@ -36306,28 +36561,28 @@
       }
     },
     "sass": {
-      "version": "1.97.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-      "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.101.0.tgz",
+      "integrity": "sha512-OL3GoQyoUdDt843DpVmDO6y2k1sc5IhUDSpu8XucEI+35neq5QivZ1iuegnpraEVTJXlQGK1gl27zKcTLEPbQw==",
       "requires": {
         "@parcel/watcher": "^2.4.1",
-        "chokidar": "^4.0.0",
-        "immutable": "^5.0.2",
+        "chokidar": "^5.0.0",
+        "immutable": "^5.1.5",
         "source-map-js": ">=0.6.2 <2.0.0"
       },
       "dependencies": {
         "chokidar": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.0.tgz",
-          "integrity": "sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+          "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
           "requires": {
-            "readdirp": "^4.0.1"
+            "readdirp": "^5.0.0"
           }
         },
         "readdirp": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
-          "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw=="
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+          "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="
         }
       }
     },
@@ -36366,12 +36621,9 @@
       "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA=="
     },
     "scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "requires": {
-        "loose-envify": "^1.1.0"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "schema-utils": {
       "version": "2.7.1",
@@ -37963,6 +38215,12 @@
           }
         }
       }
+    },
+    "use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "requires": {}
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,49 +15,41 @@
     "clean": "gatsby clean"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^7.1.0",
-    "@fortawesome/free-brands-svg-icons": "^7.1.0",
-    "@fortawesome/free-solid-svg-icons": "^7.1.0",
-    "@fortawesome/react-fontawesome": "^3.1.1",
+    "@fortawesome/fontawesome-svg-core": "^7.3.0",
+    "@fortawesome/free-brands-svg-icons": "^7.3.0",
+    "@fortawesome/free-solid-svg-icons": "^7.3.0",
+    "@fortawesome/react-fontawesome": "^3.3.1",
     "@loadable/component": "^5.16.7",
-    "ace-builds": "^1.43.5",
+    "ace-builds": "^1.44.0",
     "ansi-to-react": "^6.2.6",
-    "bootstrap": "^5.3.3",
-    "create-react-class": "^15.7.0",
-    "gatsby": "^5.16",
-    "gatsby-plugin-image": "^3.15.0",
+    "bootstrap": "^5.3.8",
+    "gatsby": "^5.16.1",
+    "gatsby-plugin-image": "^3.16.0",
     "gatsby-plugin-json-remark": "^1.1.5",
     "gatsby-plugin-netlify": "^5.1.1",
-    "gatsby-plugin-react-helmet": "^6.15.0",
     "gatsby-plugin-sass": "^6.16.0",
-    "gatsby-plugin-sharp": "^5.15",
-    "gatsby-remark-autolink-headers": "^6.15.0",
+    "gatsby-plugin-sharp": "^5.16.0",
+    "gatsby-remark-autolink-headers": "^6.16.0",
     "gatsby-remark-classes": "^1.0.2",
     "gatsby-remark-prismjs": "^7.16.0",
-    "gatsby-source-filesystem": "^5.15.0",
-    "gatsby-transformer-json": "^5.15.0",
-    "gatsby-transformer-remark": "^6.15.0",
-    "gatsby-transformer-sharp": "^5.15.0",
-    "jquery": "^3.7.1",
+    "gatsby-source-filesystem": "^5.16.0",
+    "gatsby-transformer-json": "^5.16.0",
+    "gatsby-transformer-remark": "^6.16.0",
+    "gatsby-transformer-sharp": "^5.16.0",
     "nickel-repl": "file:nickel-repl",
-    "popper.js": "^1.16.1",
     "prismjs": "^1.30.0",
-    "react": "^18.3.1",
+    "react": "^19.2.7",
     "react-ace": "^14.0.1",
     "react-bootstrap": "^2.10.10",
     "react-bootstrap-icons": "^1.11.6",
-    "react-dom": "^18.3.1",
-    "react-helmet": "^6.1.0",
-    "sass": "^1.97.3",
+    "react-dom": "^19.2.7",
+    "sass": "^1.101.0",
     "react-markdown": "^10.1.0"
   },
   "overrides": {
     "ansi-to-react": {
-      "react": "^18.2.0",
-      "react-dom": "^18.2.0"
-    },
-    "react-server-dom-webpack@0.0.0-experimental-c8b778b7f-20220825": {
-      "react": "^18.2.0"
+      "react": "^19.0.0",
+      "react-dom": "^19.0.0"
     }
   }
 }

--- a/src/components/layout-sidebar.js
+++ b/src/components/layout-sidebar.js
@@ -1,6 +1,5 @@
 import React from "react"
 import {graphql, StaticQuery} from "gatsby"
-import {Helmet} from "react-helmet"
 import Header from "./header"
 
 /**
@@ -13,12 +12,9 @@ export default function Layout({ children, sidebar }) {
   return (
     <StaticQuery
       query={graphql`
-        query SiteData {
+        query SiteDataSidebar {
           site {
             siteMetadata {
-              title
-              description
-              keywords
               menuLinks {
                 name
                 link
@@ -29,13 +25,6 @@ export default function Layout({ children, sidebar }) {
       `}
       render={(data) => (
         <React.Fragment>
-          <Helmet
-            title={data.site.siteMetadata.title}
-            meta={[
-              { name: "description", content: data.site.siteMetadata.description },
-              { name: "keywords", content: data.site.siteMetadata.keywords },
-            ]}
-          ></Helmet>
           <Header menuLinks={data.site.siteMetadata.menuLinks} />
           <div className={"container-fluid"}>
             <div className={"row"}>
@@ -44,14 +33,14 @@ export default function Layout({ children, sidebar }) {
                   "col-xl-3 col-lg-4 col-md-5 col-12 order-1 scrollable-column-md"
                 }
               >
-                <div class="column-content">{sidebar}</div>
+                <div className="column-content">{sidebar}</div>
               </div>
               <div
                 className={
                   "col-xl-9 col-lg-8 col-md-7 col-12 order-2 scrollable-column-md"
                 }
               >
-                <div class="column-content">{children}</div>
+                <div className="column-content">{children}</div>
               </div>
             </div>
           </div>
@@ -60,4 +49,3 @@ export default function Layout({ children, sidebar }) {
     />
   );
 }
-

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -1,6 +1,5 @@
 import React from "react"
 import {graphql, StaticQuery} from "gatsby"
-import {Helmet} from "react-helmet"
 import Header from "./header"
 import Footer from "./footer"
 
@@ -11,9 +10,6 @@ export default function Layout({children}) {
       query SiteData {
         site {
           siteMetadata {
-            title
-            description
-            keywords
             menuLinks {
               name
               link
@@ -24,14 +20,6 @@ export default function Layout({children}) {
     `}
             render={data => (
                 <React.Fragment>
-                    <Helmet
-                        title={data.site.siteMetadata.title}
-                        meta={[
-                            {name: "description", content: data.site.siteMetadata.description},
-                            {name: "keywords", content: data.site.siteMetadata.keywords},
-                        ]}
-                    >
-                    </Helmet>
                     <Header menuLinks={data.site.siteMetadata.menuLinks} />
                     <div>
                         {children}
@@ -42,4 +30,3 @@ export default function Layout({children}) {
         />
     )
 }
-

--- a/src/components/site-head.js
+++ b/src/components/site-head.js
@@ -1,0 +1,24 @@
+import React from "react"
+import { useStaticQuery, graphql } from "gatsby"
+
+export function SiteHead() {
+    const data = useStaticQuery(graphql`
+        query SiteMeta {
+            site {
+                siteMetadata {
+                    title
+                    description
+                    keywords
+                }
+            }
+        }
+    `)
+    const { title, description, keywords } = data.site.siteMetadata
+    return (
+        <>
+            <title>{title}</title>
+            <meta name="description" content={description} />
+            <meta name="keywords" content={keywords} />
+        </>
+    )
+}

--- a/src/pages/documentation.js
+++ b/src/pages/documentation.js
@@ -1,5 +1,7 @@
 import * as React from "react"
 import Layout from "../components/layout"
+import { SiteHead as Head } from "../components/site-head"
+export { Head }
 import { Link } from "gatsby"
 
 const IndexPage = () => {

--- a/src/pages/getting-started.js
+++ b/src/pages/getting-started.js
@@ -1,6 +1,8 @@
 import * as React from "react"
 import {useEffect} from "react"
 import Layout from "../components/layout"
+import { SiteHead as Head } from "../components/site-head"
+export { Head }
 
 import Prism from "prismjs";
 import "prismjs/components/prism-bash";

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,5 +1,7 @@
 import * as React from "react"
 import Layout from "../components/layout"
+import { SiteHead as Head } from "../components/site-head"
+export { Head }
 import {StaticImage} from "gatsby-plugin-image";
 import mergeImage from '../images/merge-2.png';
 import validateImage from '../images/validate-2.png';

--- a/src/pages/playground.js
+++ b/src/pages/playground.js
@@ -1,5 +1,7 @@
 import * as React from "react"
 import Layout from "../components/layout"
+import { SiteHead as Head } from "../components/site-head"
+export { Head }
 import PlaygroundComponent from "../components/playground-clientside";
 
 const PlaygroundPage = () => {

--- a/src/pages/stdlib/{StdlibSection.slug}.js
+++ b/src/pages/stdlib/{StdlibSection.slug}.js
@@ -1,5 +1,7 @@
 import * as React from "react";
 import Layout from "../../components/layout-sidebar";
+import { SiteHead as Head } from "../../components/site-head"
+export { Head }
 import { graphql } from "gatsby";
 import SidebarToc from "../../components/stdlib-toc";
 import { useEffect } from "react";

--- a/src/pages/user-manual/{UserManualMarkdown.slug}.js
+++ b/src/pages/user-manual/{UserManualMarkdown.slug}.js
@@ -1,5 +1,7 @@
 import * as React from "react"
 import Layout from "../../components/layout"
+import { SiteHead as Head } from "../../components/site-head"
+export { Head }
 import { graphql } from "gatsby"
 import UserManualToc from "../../components/usermanual-toc";
 


### PR DESCRIPTION
Depends #901

Threw a clanker at upgrading to latest major version of Gatsby, React, etc.